### PR TITLE
Added CPU control ports in tb top

### DIFF
--- a/env/core/vendor/core_ibex/fcov/core_ibex_fcov_bind.sv
+++ b/env/core/vendor/core_ibex/fcov/core_ibex_fcov_bind.sv
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module core_ibex_fcov_bind;
+  bind ibex_core core_ibex_fcov_if u_fcov_bind (
+    .*
+  );
+endmodule

--- a/env/core/vendor/core_ibex/fcov/core_ibex_fcov_if.sv
+++ b/env/core/vendor/core_ibex/fcov/core_ibex_fcov_if.sv
@@ -1,0 +1,318 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+interface core_ibex_fcov_if import ibex_pkg::*; (
+  input clk_i,
+  input rst_ni,
+
+  input priv_lvl_e priv_mode_id,
+  input priv_lvl_e priv_mode_if,
+  input priv_lvl_e priv_mode_lsu
+);
+  `include "dv_fcov_macros.svh"
+  import uvm_pkg::*;
+
+  typedef enum {
+    InstrCategoryALU,
+    InstrCategoryMul,
+    InstrCategoryDiv,
+    InstrCategoryBranch,
+    InstrCategoryJump,
+    InstrCategoryLoad,
+    InstrCategoryStore,
+    InstrCategoryOther,
+    InstrCategoryCSRAccess,
+    InstrCategoryEBreakDbg,
+    InstrCategoryEBreakExc,
+    InstrCategoryECall,
+    InstrCategoryMRet,
+    InstrCategoryDRet,
+    InstrCategoryWFI,
+    InstrCategoryFenceI,
+    InstrCategoryNone,
+    InstrCategoryFetchError,
+    InstrCategoryCompressedIllegal,
+    InstrCategoryUncompressedIllegal,
+    InstrCategoryCSRIllegal,
+    InstrCategoryOtherIllegal
+  } instr_category_e;
+
+  typedef enum {
+    IdStallTypeNone,
+    IdStallTypeInstr,
+    IdStallTypeLdHz,
+    IdStallTypeMem
+  } id_stall_type_e;
+
+  instr_category_e id_instr_category;
+  // Set `id_instr_category` to the appropriate category for the uncompressed instruction in the
+  // ID/EX stage.  Compressed instructions are not handled (`id_stage_i.instr_rdata_i` is always
+  // uncompressed).  When the `id_stage.instr_valid_i` isn't set `InstrCategoryNone` is the given
+  // instruction category.
+  always_comb begin
+    id_instr_category = InstrCategoryOther;
+
+    case (id_stage_i.instr_rdata_i[6:0])
+      ibex_pkg::OPCODE_LUI:    id_instr_category = InstrCategoryALU;
+      ibex_pkg::OPCODE_AUIPC:  id_instr_category = InstrCategoryALU;
+      ibex_pkg::OPCODE_JAL:    id_instr_category = InstrCategoryJump;
+      ibex_pkg::OPCODE_JALR:   id_instr_category = InstrCategoryJump;
+      ibex_pkg::OPCODE_BRANCH: id_instr_category = InstrCategoryBranch;
+      ibex_pkg::OPCODE_LOAD:   id_instr_category = InstrCategoryLoad;
+      ibex_pkg::OPCODE_STORE:  id_instr_category = InstrCategoryStore;
+      ibex_pkg::OPCODE_OP_IMM: id_instr_category = InstrCategoryALU;
+      ibex_pkg::OPCODE_OP: begin
+        if ({id_stage_i.instr_rdata_i[26], id_stage_i.instr_rdata_i[13:12]} == {1'b1, 2'b01}) begin
+          id_instr_category = InstrCategoryALU; // reg-reg/reg-imm ops
+        end else if (id_stage_i.instr_rdata_i[31:25] inside {7'b000_0000, 7'b010_0000, 7'b011_0000,
+              7'b011_0100, 7'b001_0100, 7'b001_0000, 7'b000_0101, 7'b000_0100, 7'b010_0100}) begin
+          id_instr_category = InstrCategoryALU; // RV32I and RV32B reg-reg/reg-imm ops
+        end else if (id_stage_i.instr_rdata_i[31:25] == 7'b000_0001) begin
+          if (id_stage_i.instr_rdata_i[14]) begin
+            id_instr_category = InstrCategoryDiv; // DIV*
+          end else begin
+            id_instr_category = InstrCategoryMul; // MUL*
+          end
+        end
+      end
+      ibex_pkg::OPCODE_SYSTEM: begin
+        if (id_stage_i.instr_rdata_i[14:12] == 3'b000) begin
+          case (id_stage_i.instr_rdata_i[31:20])
+            12'h000: id_instr_category = InstrCategoryECall;
+            12'h001: begin
+              if (id_stage_i.debug_ebreakm_i && priv_mode_id == PRIV_LVL_M) begin
+                id_instr_category = InstrCategoryEBreakDbg;
+              end else if (id_stage_i.debug_ebreaku_i && priv_mode_id == PRIV_LVL_U) begin
+                id_instr_category = InstrCategoryEBreakDbg;
+              end else begin
+                id_instr_category = InstrCategoryEBreakExc;
+              end
+            end
+            12'h302: id_instr_category = InstrCategoryMRet;
+            12'h7b2: id_instr_category = InstrCategoryDRet;
+            12'h105: id_instr_category = InstrCategoryWFI;
+          endcase
+        end else begin
+          id_instr_category = InstrCategoryCSRAccess;
+        end
+      end
+      ibex_pkg::OPCODE_MISC_MEM: begin
+        if (id_stage_i.instr_rdata_i[14:12] == 3'b001) begin
+          id_instr_category = InstrCategoryFenceI;
+        end
+      end
+      default: id_instr_category = InstrCategoryOther;
+    endcase
+
+    if (id_stage_i.instr_valid_i) begin
+      if (id_stage_i.instr_fetch_err_i) begin
+        id_instr_category = InstrCategoryFetchError;
+      end else if (id_stage_i.illegal_c_insn_i) begin
+        id_instr_category = InstrCategoryCompressedIllegal;
+      end else if (id_stage_i.illegal_insn_dec) begin
+        id_instr_category = InstrCategoryUncompressedIllegal;
+      end else if (id_stage_i.illegal_csr_insn_i) begin
+        id_instr_category = InstrCategoryCSRIllegal;
+      end else if (id_stage_i.illegal_insn_o) begin
+        id_instr_category = InstrCategoryOtherIllegal;
+      end
+    end else begin
+      id_instr_category = InstrCategoryNone;
+    end
+  end
+
+  // Check instruction categories calculated from instruction bits match what decoder has produced.
+
+  // The ALU category is tricky as there's no specific ALU enable and instructions that actively use
+  // the result of the ALU but aren't themselves ALU operations (such as load/store and JALR). This
+  // categorizes anything that selects the ALU as the source of register write data and enables
+  // register writes minus some exclusions as an ALU operation.
+  `ASSERT(InstrCategoryALUCorrect, id_instr_category == InstrCategoryALU |->
+      (id_stage_i.rf_wdata_sel == RF_WD_EX) && id_stage_i.rf_we_dec && ~id_stage_i.mult_sel_ex_o &&
+      ~id_stage_i.div_sel_ex_o && ~id_stage_i.lsu_req_dec && ~id_stage_i.jump_in_dec);
+
+  `ASSERT(InstrCategoryMulCorrect,
+      id_instr_category == InstrCategoryMul |-> id_stage_i.mult_sel_ex_o)
+
+  `ASSERT(InstrCategoryDivCorrect,
+      id_instr_category == InstrCategoryDiv |-> id_stage_i.div_sel_ex_o)
+
+  `ASSERT(InstrCategoryBranchCorrect,
+      id_instr_category == InstrCategoryBranch |-> id_stage_i.branch_in_dec)
+
+  `ASSERT(InstrCategoryJumpCorrect,
+      id_instr_category == InstrCategoryJump |-> id_stage_i.jump_in_dec)
+
+  `ASSERT(InstrCategoryLoadCorrect,
+      id_instr_category == InstrCategoryLoad |-> id_stage_i.lsu_req_dec && !id_stage_i.lsu_we)
+
+  `ASSERT(InstrCategoryStoreCorrect,
+      id_instr_category == InstrCategoryStore |-> id_stage_i.lsu_req_dec && id_stage_i.lsu_we)
+
+  `ASSERT(InstrCategoryCSRAccessCorrect,
+      id_instr_category == InstrCategoryCSRAccess |-> id_stage_i.csr_access_o)
+  `ASSERT(InstrCategoryEBreakDbgCorrect, id_instr_category == InstrCategoryEBreakDbg |->
+      id_stage_i.ebrk_insn && id_stage_i.controller_i.ebreak_into_debug)
+
+  `ASSERT(InstrCategoryEBreakExcCorrect, id_instr_category == InstrCategoryEBreakExc |->
+      id_stage_i.ebrk_insn && !id_stage_i.controller_i.ebreak_into_debug)
+
+  `ASSERT(InstrCategoryECallCorrect,
+      id_instr_category == InstrCategoryECall |-> id_stage_i.ecall_insn_dec)
+
+  `ASSERT(InstrCategoryMRetCorrect,
+      id_instr_category == InstrCategoryMRet |-> id_stage_i.mret_insn_dec)
+
+  `ASSERT(InstrCategoryDRetCorrect,
+      id_instr_category == InstrCategoryDRet |-> id_stage_i.dret_insn_dec)
+
+  `ASSERT(InstrCategoryWFICorrect,
+      id_instr_category == InstrCategoryWFI |-> id_stage_i.wfi_insn_dec)
+
+  `ASSERT(InstrCategoryFenceICorrect,
+      id_instr_category == InstrCategoryFenceI && id_stage_i.instr_first_cycle |->
+      id_stage_i.icache_inval_o)
+
+
+
+  id_stall_type_e id_stall_type;
+
+  // Set `id_stall_type` to the appropriate type based on signals in the ID/EX stage
+  always_comb begin
+    id_stall_type = IdStallTypeNone;
+
+    if (id_stage_i.instr_valid_i) begin
+      if (id_stage_i.stall_mem) begin
+        id_stall_type = IdStallTypeMem;
+      end
+
+      if (id_stage_i.stall_ld_hz) begin
+        id_stall_type = IdStallTypeLdHz;
+      end
+
+      if (id_stage_i.stall_multdiv || id_stage_i.stall_branch ||
+          id_stage_i.stall_jump) begin
+        id_stall_type = IdStallTypeInstr;
+      end
+    end
+  end
+
+  logic            instr_unstalled;
+  logic            instr_unstalled_last;
+  logic            id_stall_type_last_valid;
+  id_stall_type_e  id_stall_type_last;
+  instr_category_e id_instr_category_last;
+
+  // Keep track of previous values for some signals. These are used for some of the crosses relating
+  // to exception and debug entry. We want to cross different instruction categories and stalling
+  // behaviour with exception and debug entry but signals indicating entry occur a cycle after the
+  // relevant information is flushed from the pipeline.
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      // First cycle out of reset there is no last stall, use valid bit to deal with this case
+      id_stall_type_last_valid <= 1'b0;
+      id_stall_type_last       <= IdStallTypeNone;
+      instr_unstalled_last     <= 1'b0;
+      id_instr_category_last   <= InstrCategoryNone;
+    end else begin
+      id_stall_type_last_valid <= 1'b1;
+      id_stall_type_last       <= id_stall_type;
+      instr_unstalled_last     <= instr_unstalled;
+      id_instr_category_last   <= id_instr_category;
+    end
+  end
+
+  assign instr_unstalled =
+    (id_stall_type == IdStallTypeNone) && (id_stall_type_last != IdStallTypeNone) &&
+    id_stall_type_last_valid;
+
+  covergroup uarch_cg @(posedge clk_i);
+    cp_instr_category_id: coverpoint id_instr_category;
+    cp_stall_type_id: coverpoint id_stall_type;
+
+    cp_wb_reg_hz: coverpoint id_stage_i.fcov_rf_rd_wb_hz;
+    cp_wb_load_hz: coverpoint id_stage_i.fcov_rf_rd_wb_hz &&
+                              wb_stage_i.outstanding_load_wb_o;
+
+    cp_ls_error_exception: coverpoint load_store_unit_i.fcov_ls_error_exception;
+    cp_ls_pmp_exception: coverpoint load_store_unit_i.fcov_ls_pmp_exception;
+
+    cp_branch_taken: coverpoint id_stage_i.fcov_branch_taken;
+    cp_branch_not_taken: coverpoint id_stage_i.fcov_branch_not_taken;
+
+    cp_priv_mode_id: coverpoint priv_mode_id {
+      illegal_bins illegal = {PRIV_LVL_H, PRIV_LVL_S};
+    }
+    cp_priv_mode_if: coverpoint priv_mode_if {
+      illegal_bins illegal = {PRIV_LVL_H, PRIV_LVL_S};
+    }
+    cp_priv_mode_lsu: coverpoint priv_mode_lsu {
+      illegal_bins illegal = {PRIV_LVL_H, PRIV_LVL_S};
+    }
+
+    cp_irq_pending: coverpoint id_stage_i.irq_pending_i | id_stage_i.irq_nm_i;
+    cp_debug_req: coverpoint id_stage_i.controller_i.fcov_debug_req;
+
+    `DV_FCOV_EXPR_SEEN(interrupt_taken, id_stage_i.controller_i.fcov_interrupt_taken)
+    `DV_FCOV_EXPR_SEEN(debug_entry_if, id_stage_i.controller_i.fcov_debug_entry_if)
+    `DV_FCOV_EXPR_SEEN(debug_entry_id, id_stage_i.controller_i.fcov_debug_entry_id)
+    `DV_FCOV_EXPR_SEEN(pipe_flush, id_stage_i.controller_i.fcov_pipe_flush)
+
+    priv_mode_instr_cross: cross cp_priv_mode_id, cp_instr_category_id;
+
+    stall_cross: cross cp_instr_category_id, cp_stall_type_id {
+      illegal_bins illegal =
+        // Only Div, Mul, Branch and Jump instructions can see an instruction stall
+        (!binsof(cp_instr_category_id) intersect {InstrCategoryDiv, InstrCategoryMul,
+                                                 InstrCategoryBranch, InstrCategoryJump} &&
+         binsof(cp_stall_type_id) intersect {IdStallTypeInstr})
+    ||
+        // Only ALU, Mul, Div, Branch, Jump, Load, Store and CSR Access can see a load hazard stall
+        (!binsof(cp_instr_category_id) intersect {InstrCategoryALU, InstrCategoryMul,
+                                                 InstrCategoryDiv, InstrCategoryBranch,
+                                                 InstrCategoryJump, InstrCategoryLoad,
+                                                 InstrCategoryStore, InstrCategoryCSRAccess} &&
+         binsof(cp_stall_type_id) intersect {IdStallTypeLdHz});
+    }
+
+    wb_reg_hz_instr_cross: cross cp_instr_category_id, cp_wb_reg_hz;
+
+    pipe_cross: cross cp_instr_category_id, if_stage_i.if_instr_valid,
+                      wb_stage_i.fcov_wb_valid;
+
+    interrupt_taken_instr_cross: cross cp_interrupt_taken, instr_unstalled_last, id_instr_category_last {
+      illegal_bins illegal = binsof(instr_unstalled_last) intersect {0} &&
+        binsof(id_instr_category_last) intersect {InstrCategoryDiv};
+    }
+
+    debug_entry_if_instr_cross: cross cp_debug_entry_if, instr_unstalled_last, id_instr_category_last;
+    pipe_flush_instr_cross: cross cp_pipe_flush, instr_unstalled, cp_instr_category_id;
+
+    exception_stall_instr_cross: cross cp_ls_pmp_exception, cp_ls_error_exception,
+      cp_instr_category_id, cp_stall_type_id, instr_unstalled, cp_irq_pending, cp_debug_req {
+      illegal_bins illegal =
+        // Only Div, Mul, Branch and Jump instructions can see an instruction stall
+        (!binsof(cp_instr_category_id) intersect {InstrCategoryDiv, InstrCategoryMul,
+                                                 InstrCategoryBranch, InstrCategoryJump} &&
+         binsof(cp_stall_type_id) intersect {IdStallTypeInstr})
+    ||
+        // Only ALU, Mul, Div, Branch, Jump, Load, Store and CSR Access can see a load hazard stall
+        (!binsof(cp_instr_category_id) intersect {InstrCategoryALU, InstrCategoryMul,
+                                                 InstrCategoryDiv, InstrCategoryBranch,
+                                                 InstrCategoryJump, InstrCategoryLoad,
+                                                 InstrCategoryStore, InstrCategoryCSRAccess} &&
+         binsof(cp_stall_type_id) intersect {IdStallTypeLdHz});
+    }
+  endgroup
+
+  bit en_uarch_cov;
+
+  initial begin
+   void'($value$plusargs("enable_uarch_cov=%d", en_uarch_cov));
+  end
+
+  `DV_FCOV_INSTANTIATE_CG(uarch_cg, en_uarch_cov)
+endinterface

--- a/env/core/vendor/core_ibex/ibex_dv.f
+++ b/env/core/vendor/core_ibex/ibex_dv.f
@@ -113,4 +113,6 @@ ${DV_DIR}/env/core_ibex_rvfi_if.sv
 ${DV_DIR}/env/core_ibex_csr_if.sv
 ${DV_DIR}/env/core_ibex_env_pkg.sv
 ${DV_DIR}/tests/core_ibex_test_pkg.sv
+${DV_DIR}/fcov/core_ibex_fcov_if.sv
+${DV_DIR}/fcov/core_ibex_fcov_bind.sv
 ${DV_DIR}/tb/core_ibex_tb_top.sv

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -101,6 +101,8 @@ module core_ibex_tb_top;
     .instr_addr_o   (instr_mem_vif.addr   ),
     .instr_rdata_i  (instr_mem_vif.rdata  ),
     .instr_err_i    (instr_mem_vif.error  ),
+    .alert_minor_o  (                     ),
+    .alert_major_o  (                     ),
     .core_sleep_o   (dut_if.core_sleep    )
   );
 


### PR DESCRIPTION
Incorporate CPU control signal ports in ibex_core_tracing, instantiated in tb top.