### PR TITLE
Added more covergroups for capturing functioanal coverage

### DIFF
--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -224,6 +224,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.cs_registers_i.dcsr_xdebugver_cg_h.sample();
       // Sampling coverage for dcsr_d fields
       dut.u_ibex_core.cs_registers_i.dcsr_d_xdebugver_cg_h.sample();
+      // Sampling coverage for mstatus register
+      dut.u_ibex_core.cs_registers_i.m_status_reg_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -236,6 +236,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.id_stage_i.pc_mux_cg_h.sample();
       // Sampling coverage for exception pc mux selection
       dut.u_ibex_core.id_stage_i.exc_pc_mux_cg_h.sample();
+      // Sampling coverage for interrupt signals
+      dut.u_ibex_core.id_stage_i.irqs_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -232,6 +232,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.wb_stage_i.wb_instr_type_cg_h.sample();
       // Sampling coverage for regfile write data selection
       dut.u_ibex_core.id_stage_i.decoder_i.rf_wd_sel_cg_h.sample();
+      // Sampling coverage for pc mux selection
+      //dut.u_ibex_core.id_stage_i.pc_mux_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -220,8 +220,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.id_stage_i.decoder_i.csr_operations_cg_h.sample();
       // Sampling coverage for privileged modes
       dut.u_ibex_core.id_stage_i.priv_mode_cg_h.sample();
-      
-    
+      // Sampling coverage for dcsr.xdebugver fields
+      dut.u_ibex_core.cs_registers_i.dcsr_xdebugver_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -240,6 +240,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.id_stage_i.irqs_cg_h.sample();
       // Sampling coverage for exception causes
       dut.u_ibex_core.id_stage_i.exc_cause_cg_h.sample();
+      // Sampling coverage for debug causes
+      dut.u_ibex_core.id_stage_i.debug_cause_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -228,6 +228,10 @@ module core_ibex_tb_top;
       dut.u_ibex_core.cs_registers_i.m_status_reg_cg_h.sample();
       // Sampling coverage for CPU control register field
       dut.u_ibex_core.cs_registers_i.cpu_ctrl_cg_h.sample();
+      // Sampling coverage for CPU control register field
+      dut.u_ibex_core.wb_stage_i.wb_instr_type_cg_h.sample();
+      // Sampling coverage for regfile write data selection
+      dut.u_ibex_core.id_stage_i.decoder_i.rf_wd_sel_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -242,6 +242,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.id_stage_i.exc_cause_cg_h.sample();
       // Sampling coverage for debug causes
       dut.u_ibex_core.id_stage_i.debug_cause_cg_h.sample();
+      // Sampling coverage for csr register
+      dut.u_ibex_core.cs_registers_i.csr_num_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -238,6 +238,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.id_stage_i.exc_pc_mux_cg_h.sample();
       // Sampling coverage for interrupt signals
       dut.u_ibex_core.id_stage_i.irqs_cg_h.sample();
+      // Sampling coverage for exception causes
+      dut.u_ibex_core.id_stage_i.exc_cause_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -218,6 +218,9 @@ module core_ibex_tb_top;
       `endif  // BIT_MANIPULATION_ENABLED
       // Sampling coverage for csr operations
       dut.u_ibex_core.id_stage_i.decoder_i.csr_operations_cg_h.sample();
+      // Sampling coverage for privileged modes
+      dut.u_ibex_core.id_stage_i.priv_mode_cg_h.sample();
+      
     
     `endif
   end

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -244,6 +244,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.id_stage_i.debug_cause_cg_h.sample();
       // Sampling coverage for csr register
       dut.u_ibex_core.cs_registers_i.csr_num_cg_h.sample();
+      // Sampling coverage for floating point rounding modes
+      dut.u_ibex_core.id_stage_i.decoder_i.fpu_round_mode_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -233,7 +233,9 @@ module core_ibex_tb_top;
       // Sampling coverage for regfile write data selection
       dut.u_ibex_core.id_stage_i.decoder_i.rf_wd_sel_cg_h.sample();
       // Sampling coverage for pc mux selection
-      //dut.u_ibex_core.id_stage_i.pc_mux_cg_h.sample();
+      dut.u_ibex_core.id_stage_i.pc_mux_cg_h.sample();
+      // Sampling coverage for exception pc mux selection
+      dut.u_ibex_core.id_stage_i.exc_pc_mux_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -226,6 +226,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.cs_registers_i.dcsr_d_xdebugver_cg_h.sample();
       // Sampling coverage for mstatus register
       dut.u_ibex_core.cs_registers_i.m_status_reg_cg_h.sample();
+      // Sampling coverage for CPU control register field
+      dut.u_ibex_core.cs_registers_i.cpu_ctrl_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -250,6 +250,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.cs_registers_i.fp_status_cg_h.sample();
       // Sampling coverage for Dummy instruction type
       //dut.u_ibex_core.if_stage_i.dummy_instr_i.dummy_instr_type_cg_h.sample();
+      // Sampling coverage for compressed instruction type
+      dut.u_ibex_core.if_stage_i.compressed_decoder_i.compressed_instruction_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -222,6 +222,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.id_stage_i.priv_mode_cg_h.sample();
       // Sampling coverage for dcsr.xdebugver fields
       dut.u_ibex_core.cs_registers_i.dcsr_xdebugver_cg_h.sample();
+      // Sampling coverage for dcsr_d fields
+      dut.u_ibex_core.cs_registers_i.dcsr_d_xdebugver_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -246,6 +246,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.cs_registers_i.csr_num_cg_h.sample();
       // Sampling coverage for floating point rounding modes
       dut.u_ibex_core.id_stage_i.decoder_i.fpu_round_mode_cg_h.sample();
+      // Sampling coverage for floating point status flags
+      dut.u_ibex_core.cs_registers_i.fp_status_cg_h.sample();
     `endif
   end
 

--- a/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
+++ b/env/core/vendor/core_ibex/tb/core_ibex_tb_top.sv
@@ -248,6 +248,8 @@ module core_ibex_tb_top;
       dut.u_ibex_core.id_stage_i.decoder_i.fpu_round_mode_cg_h.sample();
       // Sampling coverage for floating point status flags
       dut.u_ibex_core.cs_registers_i.fp_status_cg_h.sample();
+      // Sampling coverage for Dummy instruction type
+      //dut.u_ibex_core.if_stage_i.dummy_instr_i.dummy_instr_type_cg_h.sample();
     `endif
   end
 


### PR DESCRIPTION
Implemented functional coverage for following

1) Privileged modes 
2) PC mux selection
3) Regfile write data selection
4) CSR operations
5) DCSR
6) M status register fields
7) CPU control register field
8) Type of instruction present in the writeback stage
9) Exception PC mux selection
10) Interrupt signals
11) Exception causes